### PR TITLE
fix yaml indenting (and other small md things)

### DIFF
--- a/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.Rmd
+++ b/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.Rmd
@@ -204,7 +204,8 @@ We created all the anchor link infrastructure, now we just need to tell bookdown
           includes = includes2(in_header = "header.html"),
           css = "style.css")
         ) %>% 
-      asis_yaml_output()
+      yml_pluck("output") %>% 
+      asis_yaml_output(fences = FALSE) 
     ```
 
 1. Save and Close.

--- a/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.Rmd
+++ b/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.Rmd
@@ -51,11 +51,11 @@ If you want to make linking to sections a little easier for yourself and for you
 
 1. **CSS**
 
-1. **Editing `output.yml`**  
+1. **Editing `_output.yml`**  
 
 \
 
-Adding all this in is a little bit like wrapping a present in a box, in a box, in another box... The javascript does the heavy lifting to make the links, but the javascript file has to be put in the HTML file, and the HTML file has to be referenced in the output.yml file. And bookdown then uses the output.yml file to implement the javascript code and link to the CSS that styles the anchors. 
+Adding all this in is a little bit like wrapping a present in a box, in a box, in another box... The javascript does the heavy lifting to make the links, but the javascript file has to be put in the HTML file, and the HTML file has to be referenced in the `_output.yml` file. And bookdown then uses the `_output.yml` file to implement the javascript code and link to the CSS that styles the anchors. 
 
 ![](many_boxes.jpg)
 \
@@ -189,14 +189,14 @@ Here's my [commit](https://github.com/dcossyleon/anchor_book/commit/29900eeec766
 \
 \
 
-## 4) Add anchor link elements to `output.yml`
+## 4) Add anchor link elements to `_output.yml`
 
 \
 
-We created all the anchor link infrastructure, now we just need to tell bookdown about it by referencing in our `output.yml`.
+We created all the anchor link infrastructure, now we just need to tell bookdown about it by referencing in our `_output.yml`.
 
-1. Open `output.yml`, located in your project directory
-1. Reference your HTML file with the `includes: in_header:` option underneath `bookdown::gitbook`. Make sure CSS file is also referenced. This part of your `output.yml` should look something like this:
+1. Open `_output.yml`, located in your project directory
+1. Reference your HTML file with the `includes: in_header:` option underneath `bookdown::gitbook`. Make sure CSS file is also referenced. This part of your `_output.yml` should look something like this:
 
     ```{r echo = FALSE}
     yml(author = FALSE, date = FALSE) %>% 

--- a/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.Rmd
+++ b/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.Rmd
@@ -19,6 +19,11 @@ image:
 projects: []
 ---
 
+```{r include = FALSE}
+# remotes::install_github("r-lib/ymlthis")
+library(ymlthis)
+```
+
 This summer I have been interning at RStudio on a project with [Alison Hill](https://alison.rbind.io/), and I've been spending a lot of time getting to know bookdown and its friends. In particular, I've been thinking about how to make bookdown content more easily shared and accessible. 
 
 I've noticed that some markdown files within R have built-in ways to get a link to point to specific section headings. These are called anchor links. For example, what you see here:
@@ -40,13 +45,13 @@ If you want to make linking to sections a little easier for yourself and for you
 
 **Doing this will require:**
 
-(1) **A wee bit of javascript in a .js file** (--"but I know *nothing* about javascript!" you say?--don't worry, you don't need to. Copy/paste is all you need).
+1. **A wee bit of javascript in a .js file** (--"but I know *nothing* about javascript!" you say?--don't worry, you don't need to. Copy/paste is all you need).
 
-(2) **An HTML file** if you don't already have one for your book.
+1. **An HTML file** if you don't already have one for your book.
 
-(3) **CSS**
+1. **CSS**
 
-(4) **Editing `output.yml`**  
+1. **Editing `output.yml`**  
 
 \
 
@@ -78,10 +83,11 @@ After running this command, I [commit](https://github.com/dcossyleon/anchor_book
 
 We'll make a new file with a few lines of javascript that essentially say "find every section header, and tack on a link to itself right before that header". The other important thing the javascript file will do is to add a CSS class "hasAnchor" to each of the headers. This is part of what will allow to style our anchor links with CSS in a couple steps.
 
-1) In RStudio go to *File* > *New File* > *Text File*
-2) Paste the javascript below into this file.
+1. In RStudio go to *File* > *New File* > *Text File*
 
-    ```{r, eval = FALSE}
+1. Paste the javascript below into this file.
+
+    ```{js, eval = FALSE}
 $(document).ready(function() {
 
   // Section anchors
@@ -93,7 +99,7 @@ $(document).ready(function() {
 
     ```
     
-3) Save this file as `book.js`. (You can give it another name, but the convention is usually to name the Javascript file after the project you're using it for.) Save this file in your working directory.  
+1. Save this file as `book.js`. (You can give it another name, but the convention is usually to name the Javascript file after the project you're using it for.) Save this file in your working directory.  
 
 Phew--you're done with the javascript code now!  
 
@@ -108,15 +114,15 @@ Phew--you're done with the javascript code now!
 
 We'll make an HTML file that will refer to our javascript file.
 
-1) *File* > *New File* > *Text File*
+1. *File* > *New File* > *Text File*
 
-2) Paste the line below into this file. Modify the path in quotes to point to your javascript file if yours is not in your working directory. (*Note*: This little line of code will be automatically injected within our bookdown's existing `<html>` and `<head>` tags, when we later use `includes: in_header:`, so there's no need to include these tags in this HTML file, but nothing bad will happen if you do). 
+1. Paste the line below into this file. Modify the path in quotes to point to your javascript file if yours is not in your working directory. (*Note*: This little line of code will be automatically injected within our bookdown's existing `<html>` and `<head>` tags, when we later use `includes: in_header:`, so there's no need to include these tags in this HTML file, but nothing bad will happen if you do). 
 
-    ```{r, eval = FALSE}
+    ```html
 <script src="book.js"></script>
     ```
 
-3) Save this file as `header.html` in your project directory. You can choose a different name if you'd like. 
+1. Save this file as `header.html` in your project directory. You can choose a different name if you'd like. 
 
 [Commit](https://github.com/dcossyleon/anchor_book/commit/5fcb3fcc5b355110b656f2dd0a30b7c8f142ae1b) your HTML file to GitHub. 
 
@@ -129,13 +135,13 @@ We'll make an HTML file that will refer to our javascript file.
 
 In our javascript code, we had the class "hasAnchor" be programatically added to our sections headers. So, we can now style them so that each time we hover over the section header, the anchor link icon will become visible. 
 
-1) You may already have a CSS file in your project directory (e.g. `style.css`), in which case, go to step 2. But if you don't, create a CSS file with *File* > *New File* > *Text File*. Save it as `style.css` in your project directory. Once again, a different name is okay.
+1. You may already have a CSS file in your project directory (e.g. `style.css`), in which case, go to step 2. But if you don't, create a CSS file with *File* > *New File* > *Text File*. Save it as `style.css` in your project directory. Once again, a different name is okay.
 
-2) Open your `style.css` file. Paste the CSS styles below to this file.
+1. Open your `style.css` file. Paste the CSS styles below to this file.
 
-3) Save and close. 
+1. Save and close. 
 
-    ```{r, eval = FALSE}
+    ```{css, eval = FALSE}
 /* -----------Section anchors -------------*/
 
 .book .book-body .page-wrapper .page-inner section.normal {
@@ -190,17 +196,18 @@ Here's my [commit](https://github.com/dcossyleon/anchor_book/commit/29900eeec766
 We created all the anchor link infrastructure, now we just need to tell bookdown about it by referencing in our `output.yml`.
 
 1. Open `output.yml`, located in your project directory
-2. Reference your HTML file with the `includes: in_header:` option underneath `bookdown::gitbook`. Make sure CSS file is also referenced. This part of your `output.yml` should look something like this:
+1. Reference your HTML file with the `includes: in_header:` option underneath `bookdown::gitbook`. Make sure CSS file is also referenced. This part of your `output.yml` should look something like this:
 
-    ```yaml
-    bookdown::gitbook:
-      includes:
-        in_header: header.html
-    css: style.css
-
+    ```{r echo = FALSE}
+    yml(author = FALSE, date = FALSE) %>% 
+        yml_output(bookdown::gitbook(
+          includes = includes2(in_header = "header.html"),
+          css = "style.css")
+        ) %>% 
+      asis_yaml_output()
     ```
 
-3. Save and Close.
+1. Save and Close.
 
 My [commit here](https://github.com/dcossyleon/anchor_book/commit/55e10ddfd09a50a7410add7f653228927d38cdf0).
 
@@ -221,7 +228,7 @@ View all my commits for this post [here](https://github.com/dcossyleon/anchor_bo
 
 ## Final comments
 
-When you're developing your bookdown site, you can control what the section link url will be when you add, for example, `{#mysection}` to the end of your headers. 
+When you're developing your bookdown site, you can control what the section link url will be when you add, for example, `{#mysection}` to the end of your headers.^[Read more about section header IDs in the [bookdown book](https://bookdown.org/yihui/bookdown/cross-references.html)]
 
 The hashtag you choose here is what will get included in you anchor-linked url. So, it's a good idea to choose shorter, simpler `{#section}` names than `{#really-super-long-section-names-that-make-long-urls}` to make sure your url don't become unwieldy when it's time to share. 
 

--- a/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.html
+++ b/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.html
@@ -155,13 +155,10 @@ visibility: hidden;
 <ol style="list-style-type: decimal">
 <li>Open <code>output.yml</code>, located in your project directory</li>
 <li><p>Reference your HTML file with the <code>includes: in_header:</code> option underneath <code>bookdown::gitbook</code>. Make sure CSS file is also referenced. This part of your <code>output.yml</code> should look something like this:</p>
-<pre class="yaml"><code>---
-output:
-  bookdown::gitbook:
-    includes:
-      in_header: header.html
-    css: style.css
----</code></pre></li>
+<pre class="yaml"><code>bookdown::gitbook:
+  includes:
+    in_header: header.html
+  css: style.css</code></pre></li>
 <li><p>Save and Close.</p></li>
 </ol>
 <p>My <a href="https://github.com/dcossyleon/anchor_book/commit/55e10ddfd09a50a7410add7f653228927d38cdf0">commit here</a>.</p>

--- a/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.html
+++ b/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.html
@@ -60,16 +60,17 @@ projects: []
 </p>
 <p>We’ll make a new file with a few lines of javascript that essentially say “find every section header, and tack on a link to itself right before that header”. The other important thing the javascript file will do is to add a CSS class “hasAnchor” to each of the headers. This is part of what will allow to style our anchor links with CSS in a couple steps.</p>
 <ol style="list-style-type: decimal">
-<li>In RStudio go to <em>File</em> &gt; <em>New File</em> &gt; <em>Text File</em></li>
+<li><p>In RStudio go to <em>File</em> &gt; <em>New File</em> &gt; <em>Text File</em></p></li>
 <li><p>Paste the javascript below into this file.</p>
-<pre class="r"><code>$(document).ready(function() {
+<pre class="js"><code>$(document).ready(function() {
 
   // Section anchors
   $(&#39;.section h1, .section h2, .section h3, .section h4, .section h5&#39;).each(function() {
 anchor = &#39;#&#39; + $(this).parent().attr(&#39;id&#39;);
 $(this).addClass(&quot;hasAnchor&quot;).prepend(&#39;&lt;a href=&quot;&#39; + anchor + &#39;&quot; class=&quot;anchor&quot;&gt;&lt;/a&gt;&#39;);
   });
-});</code></pre></li>
+});
+</code></pre></li>
 <li><p>Save this file as <code>book.js</code>. (You can give it another name, but the convention is usually to name the Javascript file after the project you’re using it for.) Save this file in your working directory.</p></li>
 </ol>
 <p>Phew–you’re done with the javascript code now!</p>
@@ -86,7 +87,7 @@ $(this).addClass(&quot;hasAnchor&quot;).prepend(&#39;&lt;a href=&quot;&#39; + an
 <ol style="list-style-type: decimal">
 <li><p><em>File</em> &gt; <em>New File</em> &gt; <em>Text File</em></p></li>
 <li><p>Paste the line below into this file. Modify the path in quotes to point to your javascript file if yours is not in your working directory. (<em>Note</em>: This little line of code will be automatically injected within our bookdown’s existing <code>&lt;html&gt;</code> and <code>&lt;head&gt;</code> tags, when we later use <code>includes: in_header:</code>, so there’s no need to include these tags in this HTML file, but nothing bad will happen if you do).</p>
-<pre class="r"><code>&lt;script src=&quot;book.js&quot;&gt;&lt;/script&gt;</code></pre></li>
+<pre class="html"><code>&lt;script src=&quot;book.js&quot;&gt;&lt;/script&gt;</code></pre></li>
 <li><p>Save this file as <code>header.html</code> in your project directory. You can choose a different name if you’d like.</p></li>
 </ol>
 <p><a href="https://github.com/dcossyleon/anchor_book/commit/5fcb3fcc5b355110b656f2dd0a30b7c8f142ae1b">Commit</a> your HTML file to GitHub.</p>
@@ -103,7 +104,7 @@ $(this).addClass(&quot;hasAnchor&quot;).prepend(&#39;&lt;a href=&quot;&#39; + an
 <li><p>You may already have a CSS file in your project directory (e.g. <code>style.css</code>), in which case, go to step 2. But if you don’t, create a CSS file with <em>File</em> &gt; <em>New File</em> &gt; <em>Text File</em>. Save it as <code>style.css</code> in your project directory. Once again, a different name is okay.</p></li>
 <li><p>Open your <code>style.css</code> file. Paste the CSS styles below to this file.</p></li>
 <li><p>Save and close.</p>
-<pre class="r"><code>/* -----------Section anchors -------------*/
+<pre class="css"><code>/* -----------Section anchors -------------*/
 
 .book .book-body .page-wrapper .page-inner section.normal {
   overflow: visible !important; /*so anchor link doesnt get cut off */
@@ -131,7 +132,8 @@ a.anchor {
   .hasAnchor:hover a.anchor {
 visibility: hidden;
   }
-}</code></pre></li>
+}
+</code></pre></li>
 </ol>
 <p>If you want a few more details about what’s going on here, here’s a crude summary:</p>
 <ul>
@@ -153,11 +155,13 @@ visibility: hidden;
 <ol style="list-style-type: decimal">
 <li>Open <code>output.yml</code>, located in your project directory</li>
 <li><p>Reference your HTML file with the <code>includes: in_header:</code> option underneath <code>bookdown::gitbook</code>. Make sure CSS file is also referenced. This part of your <code>output.yml</code> should look something like this:</p>
-<pre class="yaml"><code>bookdown::gitbook:
-  includes:
-    in_header: header.html
-css: style.css
-</code></pre></li>
+<pre class="yaml"><code>---
+output:
+  bookdown::gitbook:
+    includes:
+      in_header: header.html
+    css: style.css
+---</code></pre></li>
 <li><p>Save and Close.</p></li>
 </ol>
 <p>My <a href="https://github.com/dcossyleon/anchor_book/commit/55e10ddfd09a50a7410add7f653228927d38cdf0">commit here</a>.</p>
@@ -177,10 +181,16 @@ css: style.css
 </div>
 <div id="final-comments" class="section level2">
 <h2>Final comments</h2>
-<p>When you’re developing your bookdown site, you can control what the section link url will be when you add, for example, <code>{#mysection}</code> to the end of your headers.</p>
+<p>When you’re developing your bookdown site, you can control what the section link url will be when you add, for example, <code>{#mysection}</code> to the end of your headers.<a href="#fn1" class="footnote-ref" id="fnref1"><sup>1</sup></a></p>
 <p>The hashtag you choose here is what will get included in you anchor-linked url. So, it’s a good idea to choose shorter, simpler <code>{#section}</code> names than <code>{#really-super-long-section-names-that-make-long-urls}</code> to make sure your url don’t become unwieldy when it’s time to share.</p>
 <p>Now you know everything you need to get started making anchor links for your bookdown books. If this post was useful to you, then give it a shout out on twitter. Have fun sharing links of your bookdown sections!!</p>
 <p><br />
 <br />
 </p>
+</div>
+<div class="footnotes">
+<hr />
+<ol>
+<li id="fn1"><p>Read more about section header IDs in the <a href="https://bookdown.org/yihui/bookdown/cross-references.html">bookdown book</a><a href="#fnref1" class="footnote-back">↩</a></p></li>
+</ol>
 </div>

--- a/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.html
+++ b/content/post/2019-08-05-anchor-links-getting-headers-to-be-links-in-bookdown/index.html
@@ -35,11 +35,11 @@ projects: []
 <li><p><strong>A wee bit of javascript in a .js file</strong> (–“but I know <em>nothing</em> about javascript!” you say?–don’t worry, you don’t need to. Copy/paste is all you need).</p></li>
 <li><p><strong>An HTML file</strong> if you don’t already have one for your book.</p></li>
 <li><p><strong>CSS</strong></p></li>
-<li><p><strong>Editing <code>output.yml</code></strong></p></li>
+<li><p><strong>Editing <code>_output.yml</code></strong></p></li>
 </ol>
 <p><br />
 </p>
-<p>Adding all this in is a little bit like wrapping a present in a box, in a box, in another box… The javascript does the heavy lifting to make the links, but the javascript file has to be put in the HTML file, and the HTML file has to be referenced in the output.yml file. And bookdown then uses the output.yml file to implement the javascript code and link to the CSS that styles the anchors.</p>
+<p>Adding all this in is a little bit like wrapping a present in a box, in a box, in another box… The javascript does the heavy lifting to make the links, but the javascript file has to be put in the HTML file, and the HTML file has to be referenced in the <code>_output.yml</code> file. And bookdown then uses the <code>_output.yml</code> file to implement the javascript code and link to the CSS that styles the anchors.</p>
 <p><img src="many_boxes.jpg" /><br />
 </p>
 <div id="lets-get-started" class="section level2">
@@ -147,14 +147,14 @@ visibility: hidden;
 <br />
 </p>
 </div>
-<div id="add-anchor-link-elements-to-output.yml" class="section level2">
-<h2>4) Add anchor link elements to <code>output.yml</code></h2>
+<div id="add-anchor-link-elements-to-_output.yml" class="section level2">
+<h2>4) Add anchor link elements to <code>_output.yml</code></h2>
 <p><br />
 </p>
-<p>We created all the anchor link infrastructure, now we just need to tell bookdown about it by referencing in our <code>output.yml</code>.</p>
+<p>We created all the anchor link infrastructure, now we just need to tell bookdown about it by referencing in our <code>_output.yml</code>.</p>
 <ol style="list-style-type: decimal">
-<li>Open <code>output.yml</code>, located in your project directory</li>
-<li><p>Reference your HTML file with the <code>includes: in_header:</code> option underneath <code>bookdown::gitbook</code>. Make sure CSS file is also referenced. This part of your <code>output.yml</code> should look something like this:</p>
+<li>Open <code>_output.yml</code>, located in your project directory</li>
+<li><p>Reference your HTML file with the <code>includes: in_header:</code> option underneath <code>bookdown::gitbook</code>. Make sure CSS file is also referenced. This part of your <code>_output.yml</code> should look something like this:</p>
 <pre class="yaml"><code>bookdown::gitbook:
   includes:
     in_header: header.html


### PR DESCRIPTION
I think the YAML indenting here is still wrong- see my after on top (using `ymlthis`) and the before on bottom:
<img width="699" alt="Screen Shot 2019-08-06 at 9 14 01 AM" src="https://user-images.githubusercontent.com/12160301/62565811-701ce080-b83c-11e9-8f55-bd81c26d3f35.png">

Also, since you stored everything in a github repo, maybe go head and turn on github pages and provide a link (or even an iframe?) at the very top so people can explore right away instead of just the static screenshot? Just a suggestion!

---

Edited to add new ymlthis options to aid in printing here (see https://github.com/r-lib/ymlthis/commit/299d4b2d5f5cd38f1128b4870a533748ea7cd8d2):

<img width="964" alt="Screen Shot 2019-08-06 at 2 35 19 PM" src="https://user-images.githubusercontent.com/12160301/62579070-a582f780-b857-11e9-9934-9643d8a8f8fd.png">

---
then noticed `output.yml` in there, fixed to `_output.yml`